### PR TITLE
Dismiss notification on confirm

### DIFF
--- a/confirm.js
+++ b/confirm.js
@@ -36,10 +36,12 @@ function saveDomain(notificationId, type, fireCallback){
 if(isFirefox()){
   chrome.notifications.onClicked.addListener(function(notificationId){
     saveDomain(notificationId, 0, true);
+    chrome.notifications.clear(notificationId);
   });
 }else{
   chrome.notifications.onButtonClicked.addListener(function(notificationId, buttonIndex){
     saveDomain(notificationId, buttonIndex, true);
+    chrome.notifications.clear(notificationId);
   });
 }
 


### PR DESCRIPTION
Simply makes the notification pop-up go away after selecting yes or no rather than having to click the X in the corner.